### PR TITLE
BUGFIX Ensure XML is well formed when rebuilding the XML response. XML i...

### DIFF
--- a/code/PxPay.php
+++ b/code/PxPay.php
@@ -303,7 +303,7 @@ class PxPayLookupRequest extends PxPayMessage
 
 		$xml  = "<ProcessResponse>";
     	while (list($prop, $val) = each($arr))
-        	$xml .= "<$prop>$val</$prop>" ;
+        	$xml .= "<$prop>".htmlspecialchars($val, ENT_QUOTES, 'UTF-8')."</$prop>" ;
 
 		$xml .= "</ProcessResponse>";
 		return $xml;


### PR DESCRIPTION
...s badly formed when user uses special chars like & or > in the card holder name field. Typical error: "[Warning] simplexml_load_string() [function.simplexml-load-string]: Entity: line 1: parser error : xmlParseEntityRef: no name" when the response is parsed afterwards
