### PR TITLE
FIX: Add TxnData[1-3] fields to be sent to Payment Express

### DIFF
--- a/code/PaymentExpressGateway.php
+++ b/code/PaymentExpressGateway.php
@@ -38,7 +38,12 @@ class PaymentExpressGateway_PxPay extends PaymentGateway_GatewayHosted {
 
     //Set PxPay properties
     if (isset($data['Reference'])) $request->setMerchantReference($data['Reference']);
-		if (isset($data['EmailAddress'])) $request->setEmailAddress($data['EmailAddress']);
+	if (isset($data['EmailAddress'])) $request->setEmailAddress($data['EmailAddress']);
+
+	//Set TxnData for custom fields
+	if (isset($data['TxnData1'])) $request->setTxnData1($data['TxnData1']);
+	if (isset($data['TxnData2'])) $request->setTxnData2($data['TxnData2']);
+	if (isset($data['TxnData3'])) $request->setTxnData3($data['TxnData3']);
 
     $request->setUrlFail($this->cancelURL);
     $request->setUrlSuccess($this->returnURL);


### PR DESCRIPTION
Payment Express allows for custom field data using TxnData[1-3]. The functions exist for adding this data, however when processing it does not look for it.

https://www.paymentexpress.com/developer-legacy-interfaces-pxpay#generaterequest_(input_xml_document)